### PR TITLE
Revise documentation on README files and context retrieval

### DIFF
--- a/rules/base.md
+++ b/rules/base.md
@@ -72,14 +72,6 @@ enum Post_Status {}
 ### Static code analysis (PHPStan)
 For comprehensive PHPStan configuration, third-party class handling, REST API typings, and WordPress-specific patterns, see `rules/quality-assurance/phpstan.md`.
 
-#### Practical Differences (TL;DR)
-
-1. **Consumer**: `readme.txt` is machine-read by WordPress.org; `README.md` is human-read by developers.
-2. **Syntax**: `readme.txt` → strict wp.org subset; `README.md` → full Markdown.
-3. **Metadata**: Only `readme.txt` controls plugin header fields, screenshots, and changelog on wp.org.
-4. **Governance**: You **must** comply with the `readme.txt` template; you’re free to do whatever you like with `README.md`.
-
-
 ## Context Retrieval
 Use mcp tool if available to lookup examples or documentation to get more details about tools, plugins and software. The following libraries are of interest. Call them directly with their id:
 

--- a/rules/base.md
+++ b/rules/base.md
@@ -72,15 +72,6 @@ enum Post_Status {}
 ### Static code analysis (PHPStan)
 For comprehensive PHPStan configuration, third-party class handling, REST API typings, and WordPress-specific patterns, see `rules/quality-assurance/phpstan.md`.
 
-## Documentation & Repository Files
-
-### README files
-
-| File             | Purpose & Audience                                                                                                                      | Required Format                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Governance                                                                                                                         |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| **`readme.txt`** | Mandatory for assets published via the WordPress .org Plugin Directory. Parsed by wp.org to generate the plugin listing and change-log. | *Plain-text* with the canonical WordPress readme header and section order:<br>`=== Plugin Name ===`<br>`Contributors:` …<br>`Tags:` …<br>`Requires at least:` …<br>`Tested up to:` …<br>`Requires PHP:` …<br>`Stable tag:` …<br><br>Followed by the standard headings (in this order):<br>`== Description ==`<br>`== Installation ==`<br>`== Screenshots ==`<br>`== Frequently Asked Questions ==`<br>`== Changelog ==`<br>`== Upgrade Notice ==`<br><br>- Use limited wp.org markup (`*italic*`, `**bold**`, back-ticked code).<br>- No tables, HTML, or GitHub-only Markdown extensions.<br>- Keep the first 150 characters of *Description* marketing-focused: that snippet is shown in search results. | **Must** follow these rules. Treated as the single source of truth for plugin meta-data across all distribution channels.          |
-| **`README.md`**  | Optional, aimed at developers browsing the repository (e.g., on GitHub, GitLab, Bitbucket).                                             | Any valid Markdown. Badges, tables, images, extended syntax all allowed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Its structure, tone, and tooling badges are left entirely to the repository maintainers. |
-
 #### Practical Differences (TL;DR)
 
 1. **Consumer**: `readme.txt` is machine-read by WordPress.org; `README.md` is human-read by developers.
@@ -90,9 +81,14 @@ For comprehensive PHPStan configuration, third-party class handling, REST API ty
 
 
 ## Context Retrieval
-Use the context7 mcp server if it is available to lookup examples or documentation to get more details about tools, plugins and software. The following libraries are out of interest. Call them directly with their id:
-* Bricks Builder (Page Builder for WordPress): `/digisavvy-inc/bricks-builder-docs`
-* Advanced Custom Field Pro ACF (Custom Fields, Post Types, Taxonomies): `/advancedcustomfields/acf`
-* WP Gridbuilder (Filtering, Facets): `/context7/wpgridbuilder`
-* WS Form (Forms that are highly dynamic and can be customized using code): `/context7/wsform-knowledgebase`
-* Automatic.css ACSS (Modern css framework that closely works with etch builder, bricks builder or standalone): `/context7/automaticcss`
+Use mcp tool if available to lookup examples or documentation to get more details about tools, plugins and software. The following libraries are of interest. Call them directly with their id:
+
+|ID|Name|Description|MCP Server
+|---|---|---|---|
+|/digisavvy-inc/bricks-builder-docs|Bricks Builder|Agency focused Page/Theme Builder|context7|
+|/advancedcustomfields/acf|Advanced Custom Field Pro (ACF)|Adding Custom Fields, Post Types, Taxonomies|context7|
+|/context7/wpgridbuilder|WP Gridbuilder|Advanced filtering of queries using Facets|context7|
+|/context7/wsform-knowledgebase|WS Form|Forms that are highly dynamic and can be customized using code|context7|
+|/context7/automaticcss|Automatic.css (ACSS)|Modern css framework that closely works with etch builder, bricks builder or standalone|context7|
+|/wordpress/abilities-api|Abilities API|Declaring and discovering abilities in a standardized way. Can expose Abilities to AI.|context7|
+|/wordpress/mcp-adapter|MCP Adapter|MCP integration that allows developers to expose abilities, registered with abilities API, as Model Context Protocol (MCP) tools, resources, and prompts for AI agents.|context7|

--- a/rules/documentation.md
+++ b/rules/documentation.md
@@ -9,6 +9,13 @@ Guidline for how to document code functionality, changelogs and developer instru
 | [**`readme.txt`**](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/)| Mandatory for assets published via the WordPress .org Plugin Directory. Parsed by wp.org to generate the plugin listing and change-log. | *Plain-text* with the canonical WordPress readme header and section order:<br>`=== Plugin Name ===`<br>`Contributors:` …<br>`Tags:` …<br>`Requires at least:` …<br>`Tested up to:` …<br>`Requires PHP:` …<br>`Stable tag:` …<br><br>Followed by the standard headings (in this order):<br>`== Description ==`<br>`== Installation ==`<br>`== Screenshots ==`<br>`== Frequently Asked Questions ==`<br>`== Changelog ==`<br>`== Upgrade Notice ==`<br><br>- Use limited wp.org markup (`*italic*`, `**bold**`, back-ticked code).<br>- No tables, HTML, or GitHub-only Markdown extensions.<br>- Keep the first 150 characters of *Description* marketing-focused: that snippet is shown in search results. | **Must** follow these rules. Treated as the single source of truth for plugin meta-data across all distribution channels.          |
 | **`README.md`**  | Optional, aimed at developers browsing the repository (e.g., on GitHub, GitLab, Bitbucket).                                             | Any valid Markdown. Badges, tables, images, extended syntax all allowed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Its structure, tone, and tooling badges are left entirely to the repository maintainers. |
 
+### Practical Differences (TL;DR)
+
+1. **Consumer**: `readme.txt` is machine-read by WordPress.org; `README.md` is human-read by developers.
+2. **Syntax**: `readme.txt` → strict wp.org subset; `README.md` → full Markdown.
+3. **Metadata**: Only `readme.txt` controls plugin header fields, screenshots, and changelog on wp.org.
+4. **Governance**: You **must** comply with the `readme.txt` template; you’re free to do whatever you like with `README.md`.
+
 ## Docs folder
 It is common practice to add a docs folder in the root of a repository containing markdown files. Follow these rules when adding documentation:
 

--- a/rules/documentation.md
+++ b/rules/documentation.md
@@ -1,0 +1,30 @@
+# Documentation & Repository Files
+
+Guidline for how to document code functionality, changelogs and developer instructions.
+
+## README files
+
+| File             | Purpose & Audience                                                                                                                      | Required Format                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Governance                                                                                                                         |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| [**`readme.txt`**](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/)| Mandatory for assets published via the WordPress .org Plugin Directory. Parsed by wp.org to generate the plugin listing and change-log. | *Plain-text* with the canonical WordPress readme header and section order:<br>`=== Plugin Name ===`<br>`Contributors:` …<br>`Tags:` …<br>`Requires at least:` …<br>`Tested up to:` …<br>`Requires PHP:` …<br>`Stable tag:` …<br><br>Followed by the standard headings (in this order):<br>`== Description ==`<br>`== Installation ==`<br>`== Screenshots ==`<br>`== Frequently Asked Questions ==`<br>`== Changelog ==`<br>`== Upgrade Notice ==`<br><br>- Use limited wp.org markup (`*italic*`, `**bold**`, back-ticked code).<br>- No tables, HTML, or GitHub-only Markdown extensions.<br>- Keep the first 150 characters of *Description* marketing-focused: that snippet is shown in search results. | **Must** follow these rules. Treated as the single source of truth for plugin meta-data across all distribution channels.          |
+| **`README.md`**  | Optional, aimed at developers browsing the repository (e.g., on GitHub, GitLab, Bitbucket).                                             | Any valid Markdown. Badges, tables, images, extended syntax all allowed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Its structure, tone, and tooling badges are left entirely to the repository maintainers. |
+
+## Docs folder
+It is common practice to add a docs folder in the root of a repository containing markdown files. Follow these rules when adding documentation:
+
+* Create well foratted markdown with a hierarchical structure of headings
+* Add examples but keep them as short as possible to demonstrate a certain implementation.
+* Be precise and not overly verbose while keeping the docs human and machine readable
+
+### Docs folder structure
+The following folder structure is a good starter.
+```
+docs/
+├── README.md                     # Introduction to docs/plugin/theme functionality
+├── architecture/
+|   ├── Readme.md
+|   └── Detail1.md
+└── guides/
+    ├── Howto1.md
+    └── Howto2.md
+```


### PR DESCRIPTION
This pull request improves the documentation guidelines for repository files and updates instructions for context retrieval tools. The main changes include moving and expanding documentation rules into a dedicated file, clarifying the differences between `readme.txt` and `README.md`, and updating the list and format of supported MCP context libraries.

**Documentation guidelines:**

* Added a new `rules/documentation.md` file with comprehensive instructions for documenting code, changelogs, and developer instructions, including best practices for README files and docs folder structure.
* Removed detailed documentation and repository file guidelines from `rules/base.md`, consolidating them into the new documentation file for better organization.

**Context retrieval tooling:**

* Updated context retrieval instructions in `rules/base.md` to use the `mcp` tool and provided a clearer, tabular list of supported libraries, including new entries for Abilities API and MCP Adapter.